### PR TITLE
readme: add instructions for libsodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ fail_on(ret != VRT_SUCCESS);
 
 The output will be placed in `out_midpoint`. Check `vrt_test.c` and `vrt_client_unix.c` for an example on how to use it.
 
+__If you already have libsodium in your project__, then do not compile
+`tweetnacl.c`, but include `sodium.h` instead of `tweetnacl.h`. Things
+should work out of the box. The only call to libsodium is `crypto_sign_open`.
+
 For a list of current roughtime servers, see
 https://github.com/cloudflare/roughtime/blob/master/ecosystem.json
 


### PR DESCRIPTION
Your project may already link against `libsodium`, in that case, do not use `tweetnacl`.