### PR TITLE
feat: add cbmc proof for memory safety

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,18 @@
+name: Run cbmc_verify
+on: [push, pull_request]
+jobs:
+  cmbc_verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: |
+          curl -o cbmc.deb -L https://github.com/diffblue/cbmc/releases/download/cbmc-5.54.0/ubuntu-20.04-cbmc-5.54.0-Linux.deb
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+                                  ./cbmc.deb
+          rm -rf cbmc.deb
+      - name: Run proof
+        run: |
+          cd verify
+          cbmc vrt_cbmc_harness.c ../vrt.c --function vrt_cbmc_harness --unwind 3 --bounds-check --pointer-check

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,4 +15,4 @@ jobs:
       - name: Run proof
         run: |
           cd verify
-          cbmc vrt_cbmc_harness.c ../vrt.c --function vrt_cbmc_harness --unwind 3 --bounds-check --pointer-check
+          cbmc vrt_cbmc_harness.c ../vrt.c --function vrt_cbmc_harness --unwind 1 --bounds-check --pointer-check

--- a/verify/vrt_cbmc_harness.c
+++ b/verify/vrt_cbmc_harness.c
@@ -1,0 +1,31 @@
+#include "../vrt.h"
+
+#define CHECK(x)                                                               \
+  do {                                                                         \
+    int ret;                                                                   \
+    if ((ret = x) != VRT_SUCCESS) {                                            \
+      return (ret);                                                            \
+    }                                                                          \
+  } while (0)
+
+#define CHECK_TRUE(x, errorcode)                                               \
+  do {                                                                         \
+    if (!(x))                                                                  \
+      return (errorcode);                                                      \
+  } while (0)
+
+#define CHECK_NOT_NULL(x) CHECK_TRUE((x) != NULL, VRT_ERROR_NULL_ARGUMENT)
+
+#define RECV_BUFFER_LEN 1024
+
+void vrt_cbmc_harness(void) {
+	uint8_t nonce_sent[VRT_NONCE_SIZE];
+	uint8_t reply[RECV_BUFFER_LEN];
+	uint8_t pk[32];
+	uint64_t *out_midp;
+	uint32_t *out_radii;
+
+	CHECK(vrt_parse_response(nonce_sent, sizeof(nonce_sent),
+                              reply, sizeof(reply), pk,
+                              out_midp, out_radii));
+}

--- a/vrt.c
+++ b/vrt.c
@@ -43,6 +43,7 @@ VISIBILITY_ONLY_TESTING vrt_ret_t vrt_blob_r32(vrt_blob_t *b,
                                                uint32_t word_index,
                                                uint32_t *out) {
   CHECK_NOT_NULL(b);
+  CHECK_NOT_NULL(b->data);
   CHECK_NOT_NULL(out);
 
   // mind integer overflow if this condition was written as 4*word_index >=


### PR DESCRIPTION
cbmc is an easy to use bounds checker. This commit checks for memory safety (array bounds checks and checks for the safe use of pointers) and adds a github action to test this in CI.