### PR TITLE
ci: add fuzzers to ci via ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+# RUN apt-get update
+COPY . $SRC/vroughtime
+WORKDIR $SRC/vroughtime
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+
+cd tests/fuzz
+./compile.sh

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yaml
+++ b/.github/workflows/cflite_pr.yaml
@@ -1,0 +1,47 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        - undefined
+        - memory
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: c
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to only run fuzzers that are affected
+        # by the PR.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to download the corpus produced by
+        # batch fuzzing.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/examples/compile.sh
+++ b/examples/compile.sh
@@ -6,7 +6,7 @@ CC=clang
 
 rm -f *.o client
 $CC -c ../tweetnacl.c -o tweetnacl.o
-$CC -Wall -Werror -g -fsanitize=address,undefined -c ../vrt.c -o vrt.o 
+$CC -Wall -Werror -g -fsanitize=address,undefined -c ../vrt.c -o vrt.o
 
 $CC -I ../ -Wall -Werror -g -fsanitize=address,undefined -o client vrt_client_unix.c vrt.o tweetnacl.o && ./client
 

--- a/tests/fuzz/compile.sh
+++ b/tests/fuzz/compile.sh
@@ -2,24 +2,33 @@
 
 set -euxo pipefail
 
-CC=clang
-
 rm -f *.o
 
-$CC -c tweetnacl_stub.c -o tweetnacl_stub.o
-$CC -DTESTING_VISIBILITY -Wall -Werror -g -fsanitize=address,undefined -c ../../vrt.c -o vrt_testing.o 
+# non-clusterfuzz usage
+#$CC -c tweetnacl_stub.c -o tweetnacl_stub.o
+#$CC -DTESTING_VISIBILITY -Wall -Werror -g -fsanitize=address,undefined -c ../../vrt.c -o vrt_testing.o 
+#$CXX -I../../ -DTARGET_FUZZ_1 -DTESTING_VISIBILITY -g -fsanitize=address,undefined,fuzzer vrt_fuzz.cc -o fuzzer1 vrt_testing.o tweetnacl_stub.o
+#$CXX -I../../ -DTARGET_FUZZ_2 -DTESTING_VISIBILITY -g -fsanitize=address,undefined,fuzzer vrt_fuzz.cc -o fuzzer2 vrt_testing.o tweetnacl_stub.o
+#$CXX -I../../ -DTARGET_FUZZ_3 -DTESTING_VISIBILITY -g -fsanitize=address,undefined,fuzzer vrt_fuzz.cc -o fuzzer3 vrt_testing.o tweetnacl_stub.o
 
-for TARGET_FUZZ in TARGET_FUZZ_1 TARGET_FUZZ_2 TARGET_FUZZ_3; do
-    rm -f fuzz && $CXX -D$TARGET_FUZZ -DTESTING_VISIBILITY -g -fsanitize=address,undefined,fuzzer vrt_fuzz.cc -o fuzz vrt_testing.o tweetnacl_stub.o
 
-    # very quick test to spot problems early on
-    ./fuzz -max_total_time=10
-done
+# clusterfuzz usage: need to use LIB_FUZZING_ENGINE, see https://google.github.io/clusterfuzzlite/build-integration/#compilation-env
+$CC $CFLAGS -c tweetnacl_stub.c -o tweetnacl_stub.o
+$CC $CFLAGS -DTESTING_VISIBILITY -c ../../vrt.c -o vrt_testing.o 
+$CXX $CXXFLAGS -I../../ -DTARGET_FUZZ_1 -DTESTING_VISIBILITY vrt_fuzz.cc -o fuzzer1 $LIB_FUZZING_ENGINE vrt_testing.o tweetnacl_stub.o 
+$CXX $CXXFLAGS -I../../ -DTARGET_FUZZ_2 -DTESTING_VISIBILITY vrt_fuzz.cc -o fuzzer2 $LIB_FUZZING_ENGINE vrt_testing.o tweetnacl_stub.o
+$CXX $CXXFLAGS -I../../ -DTARGET_FUZZ_3 -DTESTING_VISIBILITY vrt_fuzz.cc -o fuzzer3 $LIB_FUZZING_ENGINE vrt_testing.o tweetnacl_stub.o
 
-for TARGET_FUZZ in TARGET_FUZZ_1 TARGET_FUZZ_2 TARGET_FUZZ_3; do
-    rm -f fuzz && $CXX -D$TARGET_FUZZ -DTESTING_VISIBILITY -g -fsanitize=address,undefined,fuzzer vrt_fuzz.cc -o fuzz vrt_testing.o tweetnacl_stub.o
+cp fuzzer* $OUT/
 
-    # more comprehensive run
-    ./fuzz -max_total_time=1000
-done
+# quick test to spot problems early on
 
+#./fuzzer1 -max_total_time=10
+#./fuzzer2 -max_total_time=10
+#./fuzzer3 -max_total_time=10
+
+# more comprehensive run
+
+#./fuzzer1 -max_total_time=1000
+#./fuzzer2 -max_total_time=1000
+#./fuzzer3 -max_total_time=1000

--- a/tests/fuzz/tweetnacl_stub.c
+++ b/tests/fuzz/tweetnacl_stub.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include "tweetnacl.h"
+#include "../../tweetnacl.h"
 
 int crypto_hash_sha512(unsigned char *a,const unsigned char *b,unsigned long long c)
 {


### PR DESCRIPTION
Before we were running the fuzzing test on a dedicated dev machine. We live in 2022 and we want to offload this to a Github action via ClusterFuzzLite. This has the additional advantage that docker images for fuzzing are managed for us. Currently this boils down to the fantastic LLVM's libfuzzer.

The disadvantage is that PRs now take 10+ minutes (I assume we can bypass the longer checks for PRs that don't touch code).

Followed https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/